### PR TITLE
Remove '>>>>>>> naconner-master' breaking install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,5 @@
     "lodash": "^2.4.1",
     "promptly": "~0.2.0",
     "lamassu-config": "~1.0.0"
->>>>>>> naconner-master
   }
 }


### PR DESCRIPTION
Results in:

```
npm ERR! Failed to parse json
npm ERR! Unexpected token >
npm ERR! File: /tmp/npm-1763-4ATpjlUs/1424493703006-0.504345720866695/tmp.tgz-unpack/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse
 
npm ERR! System Linux 3.13.0-43-generic
npm ERR! command "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! cwd /usr/local/lib/node_modules/lamassu-admin
npm ERR! node -v v0.10.32
npm ERR! npm -v 1.4.28
npm ERR! file /tmp/npm-1763-4ATpjlUs/1424493703006-0.504345720866695/tmp.tgz-unpack/package.json
npm ERR! code EJSONPARSE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /usr/local/lib/node_modules/lamassu-admin/npm-debug.log
npm ERR! not ok code 0
```